### PR TITLE
msm8998:fix duplicate errors

### DIFF
--- a/vendor/msm8998/file_contexts
+++ b/vendor/msm8998/file_contexts
@@ -51,9 +51,6 @@
 /dev/block/platform/soc/1da4000.ufshc/by-name/rawdump                            u:object_r:rawdump_block_device:s0
 /sys/kernel/dload/emmc_dload                                                     u:object_r:sysfs_emmc_dload:s0
 
-#Same hal process libs
-/(vendor|system/vendor)/lib(64)?/hw/gralloc\.msm8998\.so        u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/vulkan\.msm8998\.so         u:object_r:same_process_hal_file:s0
 
 # A/B partitions.
 /dev/block/platform/soc/1da4000.ufshc/by-name/abl_[ab]          u:object_r:custom_ab_block_device:s0


### PR DESCRIPTION
-already present in device/QCOM sepolicy/vendor/common/file_contexts